### PR TITLE
Menu-specific template loads correctly.

### DIFF
--- a/joomlaoverride.php
+++ b/joomlaoverride.php
@@ -12,6 +12,13 @@ defined('_JEXEC') or die;
 
 jimport('joomla.plugin.plugin');
 
+require_once 'helper/override.php';
+require_once 'core/loader.php';
+require_once 'helper/codepool.php';
+require_once 'helper/component.php';
+		
+JoomlaOverrideHelperCodepool::initialize();
+
 /**
  * Joomla! Override Plugin
  *
@@ -21,16 +28,14 @@ jimport('joomla.plugin.plugin');
  */
 class PlgSystemJoomlaOverride extends JPlugin
 {
-	public function __construct($subject, $config)
+	/**
+	 * onAfterRoute function.
+	 * 
+	 * @access public
+	 * @return void
+	 */
+	public function onAfterRoute()
 	{
-		parent::__construct($subject, $config);
-		
-		require_once 'helper/override.php';
-		require_once 'core/loader.php';
-		require_once 'helper/codepool.php';
-		require_once 'helper/component.php';
-		
-		JoomlaOverrideHelperCodepool::initialize();
 		//template name
 		$template = JFactory::getApplication()->getTemplate();
 		
@@ -49,16 +54,7 @@ class PlgSystemJoomlaOverride extends JPlugin
 		//template code path
 		$includePath[] = JPATH_THEMES.'/'.$template.'/code';
 		JoomlaOverrideHelperCodepool::addCodePath($includePath);
-	}
-	
-	/**
-	 * onAfterRoute function.
-	 * 
-	 * @access public
-	 * @return void
-	 */
-	public function onAfterRoute()
-	{
+
 		$this->option = JFactory::getApplication()->input->get('option');
 		$this->extension = JFactory::getApplication()->input->get('extension');
 		


### PR DESCRIPTION
Solution to menu-specific template not being loaded when joomla override plugin is enabled.

It appears that the menu-specific template is not available until onAfterRoute is triggered (onAfterInitialise results in the default template name being returned even though a different template has been defined in the menu item assignment).

Most probably results from the client request not being available until onAfterRoute is fired; i.e. what the user has requested (itemId) has not been made available to the getTemplate method therefore it falls back to the default template.
