### PR TITLE
Php55 fixes

### DIFF
--- a/core/loader.php
+++ b/core/loader.php
@@ -3,10 +3,10 @@ spl_autoload_register(function($class_name){
 	$original_class = $class_name;
 	$sufix = JoomlaOverrideHelperOverride::SUFIX;
 	$prefix = JoomlaOverrideHelperOverride::PREFIX;
-	
+
 	$class_prefix = substr($class_name,0,strlen($prefix));
 	$class_sufix = substr($class_name,strlen($sufix) * -1);
-	
+
 	if (
 		(!empty($prefix) && !empty($class_prefix) && ($class_prefix != $prefix))
 		||
@@ -15,7 +15,7 @@ spl_autoload_register(function($class_name){
 	{
 		return false;
 	}
-	
+
 	//check for com_class_namedefault
 	if (!empty($prefix))
 	{
@@ -25,14 +25,14 @@ spl_autoload_register(function($class_name){
 	{
 		$class_name = substr($class_name,0,strlen($sufix) * -1);
 	}
-	
-	
+
+
 	$class_name = strtolower($class_name);
 	if (strpos($class_name,'controller') !== false)
 	{
 		$format = JFactory::getApplication()->input->get('format');
-		$parts = split('controller',$class_name);
-		
+		$parts = explode('controller',$class_name);
+
 		$file = '/components/com_'.strtolower($parts[0]);
 		if (count($parts) > 1)
 		{
@@ -46,7 +46,7 @@ spl_autoload_register(function($class_name){
 		else {
 			$file .= '/controllers.php';
 		}
-		
+
 		if (is_file(JPATH_BASE.$file))
 		{
 			if (!class_exists($original_class))
@@ -57,10 +57,10 @@ spl_autoload_register(function($class_name){
 	}
 	if (strpos($class_name,'model') !== false)
 	{
-		$parts = split('model',$class_name);
-		
+		$parts = explode('model',$class_name);
+
 		$file = '/components/com_'.strtolower($parts[0]).'/models/'.strtolower(end($parts)).'.php';
-		
+
 		if (is_file(JPATH_BASE.$file))
 		{
 			if (!class_exists($original_class))
@@ -72,13 +72,13 @@ spl_autoload_register(function($class_name){
 	if (strpos($class_name,'view') !== false)
 	{
 		$format = JFactory::getApplication()->input->get('format','html');
-		$parts = split('view',$class_name);
-		
+		$parts = explode('view',$class_name);
+
 		$file = '/components/com_'.strtolower($parts[0]).'/views/'.strtolower(end($parts)).'/view.'.$format.'.php';
-		
+
 		if (is_file(JPATH_BASE.$file))
 		{
-			
+
 			if (!class_exists($original_class))
 			{
 				JoomlaOverrideHelperOverride::load(JoomlaOverrideHelperOverride::fixDefines(JoomlaOverrideHelperOverride::createDefaultClass(JPATH_BASE.$file)));
@@ -87,13 +87,13 @@ spl_autoload_register(function($class_name){
 	}
 	if (strpos($class_name,'table') !== false)
 	{
-		$parts = split('table',$class_name);
-		
+		$parts = explode('table',$class_name);
+
 		$file = '/components/com_'.strtolower($parts[0]).'/tables/'.strtolower(end($parts)).'.php';
-		
+
 		if (is_file(JPATH_BASE.$file))
 		{
-			
+
 			if (!class_exists($original_class))
 			{
 				JoomlaOverrideHelperOverride::load(JoomlaOverrideHelperOverride::fixDefines(JoomlaOverrideHelperOverride::createDefaultClass(JPATH_BASE.$file)));

--- a/helper/component.php
+++ b/helper/component.php
@@ -6,7 +6,7 @@
 * @copyright Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
 * @license GNU General Public License version 2 or later; see LICENSE.txt
 */
- 
+
 // no direct access
 defined('_JEXEC') or die;
 
@@ -22,7 +22,7 @@ class JoomlaOverrideHelperComponent
 {
 	/**
 	 * Exception data to prevent override classes
-	 * 
+	 *
 	 * @var array
 	 */
 	static private $_exception = array();
@@ -50,7 +50,7 @@ class JoomlaOverrideHelperComponent
 			define('JPATH_SOURCE_COMPONENT',JPATH_BASE.'/components/'.$option);
 			define('JPATH_SOURCE_COMPONENT_SITE',JPATH_SITE.'/components/'.$option);
 			define('JPATH_SOURCE_COMPONENT_ADMINISTRATOR',JPATH_ADMINISTRATOR.'/components/'.$option);
-			
+
 			foreach($componentOverrideFiles as $componentFile)
 			{
 				if($filePath = JPath::find(JoomlaOverrideHelperCodepool::addCodePath(),$componentFile))
@@ -62,7 +62,7 @@ class JoomlaOverrideHelperComponent
 						{
 							JoomlaOverrideHelperOverride::load(JoomlaOverrideHelperOverride::fixDefines(JoomlaOverrideHelperOverride::createDefaultClass(JPATH_BASE.'/components/'.$componentFile)));
 						}
-						
+
 						require_once $filePath;
 					}
 					else
@@ -84,7 +84,7 @@ class JoomlaOverrideHelperComponent
 	 * @param mixed $option
 	 * @return void
 	 */
-	private function loadComponentFiles($option)
+	static private function loadComponentFiles($option)
 	{
 		$JPATH_COMPONENT = JPATH_BASE.'/components/'.$option;
 		$files = array();
@@ -210,7 +210,7 @@ class JoomlaOverrideHelperComponent
 
 	/**
 	 * Check if exists and exception for specific component/application or if has a specific exceptions by types(models, controllers, views)
-	 * 
+	 *
 	 * @param string $option
 	 * @param string $key
 	 */
@@ -226,7 +226,7 @@ class JoomlaOverrideHelperComponent
 
 	/**
 	 * String register and exception data to override specific files
-	 * 
+	 *
 	 * @param string $option
 	 * @param string $application
 	 * @param array $data


### PR DESCRIPTION
A few fixes for warning messages now in php 5.5, replaced split() with explode() and changed method dfinition to static
